### PR TITLE
Fixed Skype download location

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,6 @@
 class skype {
   package { 'Skype':
     provider => 'appdmg',
-    source   => 'http://www.skype.com/go/getskype-macosx.dmg',
+    source   => 'http://download.skype.com/macosx/Skype_6.3.59.582.dmg',
   }
 }

--- a/spec/classes/skype_spec.rb
+++ b/spec/classes/skype_spec.rb
@@ -4,7 +4,7 @@ describe 'skype' do
   it do
     should contain_package('Skype').with({
       :provider => 'appdmg',
-      :source   => 'http://www.skype.com/go/getskype-macosx.dmg',
+      :source   => 'http://download.skype.com/macosx/Skype_6.3.59.582.dmg',
     })
   end
 end


### PR DESCRIPTION
The generic URL yields a .dmg that is not mountable by OS X.
