### PR TITLE
Deprecate module in favour of brewcask

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+**This Boxen module is now deprecated. The advised method for installing applications with Boxen is to now use [homebrew-cask](http://caskroom.io/). Add the following to your manifest to install Skype using brewcask:**
+
+```puppet
+package { 'skype': provider => 'brewcask' }
+```
+
+---
+
 # Skype Puppet Module for Boxen
 
 [![Build Status](https://travis-ci.org/boxen/puppet-skype.png?branch=master)](https://travis-ci.org/boxen/puppet-skype)
@@ -5,7 +13,7 @@
 ## Usage
 
 ```puppet
-include skype 
+include skype
 ```
 
 ## Required Puppet Modules


### PR DESCRIPTION
Boxen is switching to use brewcask instead of app wrapper modules. This PR adds a notice to the `README.md` deprecating the module in favour of installing with brewcask with instructions on how to install.